### PR TITLE
Bugfix for Issue #228

### DIFF
--- a/github.py
+++ b/github.py
@@ -58,10 +58,14 @@ def getRepo():
 		return val # return the repo saved in the settings file
 
 	# Get the active git repo
+	origin = False
 	with open('.git/config') as f:
 		for line in f:
-			if "url = " in line:
+			if "[remote \"origin\"]" in line: 
+				origin = True
+			if "url = " in line and origin:
 				r = line.split("=")[1].split("github.com/")[1].split("/")[1].replace(".git\n", "")
+				origin = False
 
 	# Add to our settings file
 	if r:
@@ -76,9 +80,13 @@ def getOwner():
 
 	# Get the active git repo
 	with open('.git/config') as f:
+		origin = False
 		for line in f:
-			if "url = " in line:
+			if "[remote \"origin\"]" in line: 
+				origin = True
+			if "url = " in line and origin:
 				r = line.split("=")[1].split("github.com/")[1].split("/")[0]
+				origin = False
 
 	# Add to our settings file
 	if r:


### PR DESCRIPTION
This bugfix adds a boolean that is set to true when the origin remote is encountered, and then back to false when the property being searched for is found. This way it will not try to read from lines with incorrect remote formats and will not overwrite info from the origin remote with other remote info.